### PR TITLE
Allow access to the installer from other devices

### DIFF
--- a/client/services/tizenbrew-installer-service/index.js
+++ b/client/services/tizenbrew-installer-service/index.js
@@ -15,7 +15,7 @@ module.exports.onStart = function () {
     const { join, dirname } = require('path');
     const { parsePackage, installPackage } = require('./utils/PackageInstallation.js');
     const { Connection, Events } = require('./utils/wsCommunication.js');
-    const { homedir } = require('os');
+    const { homedir, networkInterfaces } = require('os');
     const AccessInfoHTMLPage = require('./utils/HTMLPage.js');
     const PushFile = require('./utils/FilePusher.js');
 
@@ -33,7 +33,12 @@ module.exports.onStart = function () {
     const app = express();
     if (!isTV) {
         // Enable static file serving for frontend
-        console.log('Open up http://localhost:8091/ui/dist/index.html to access the TizenBrew Installer.');
+        const exposedAddress = 
+            Object.values(networkInterfaces())
+                .flat()
+                .filter(networkInterface => !networkInterface.internal)[0]
+                .address;  // Get the first non-internal network interface IP address
+        console.log(`Open up http://${exposedAddress}:8091/ui/dist/index.html to access the TizenBrew Installer.`);
         if (existsSync(`${process.platform === 'win32' ? 'C:\\' : '/'}snapshot/client`)) {
             app.use(express.static(`${process.platform === 'win32' ? 'C:\\' : '/'}snapshot/client`));
         } else app.use(express.static(join(__dirname, '../../')));

--- a/client/ui/src/app.jsx
+++ b/client/ui/src/app.jsx
@@ -74,7 +74,8 @@ export default function App() {
 
 
 function startService(context) {
-  const testWS = new WebSocket('ws://localhost:8091');
+  const host = location?.host ?? 'localhost:8091';
+  const testWS = new WebSocket(`ws://${host}`);
 
   testWS.onerror = () => {
     const pkgId = tizen.application.getCurrentApplication().appInfo.packageId;

--- a/client/ui/src/components/WebSocketClient.js
+++ b/client/ui/src/components/WebSocketClient.js
@@ -12,7 +12,8 @@ const Events = {
 class Client {
     constructor(context) {
         this.context = context;
-        this.socket = new WebSocket('ws://localhost:8091');
+        const host = location?.host ?? 'localhost:8091';
+        this.socket = new WebSocket(`ws://${host}`);
         this.socket.onopen = this.onOpen.bind(this);
         this.socket.onmessage = this.onMessage.bind(this);
         this.socket.onerror = () => location.reload();


### PR DESCRIPTION
Replace hardcoded localhost references with the actual LAN IP on the server side and location.host on the client side, allowing access to the installer from other devices on the same network.